### PR TITLE
GH-1 : Added override to the function as suggested by SonarQube

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.application'
-
 buildscript {
     repositories {
         google()
@@ -9,6 +7,12 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.2.1'
     }
 }
+
+plugins {
+    id "org.sonarqube" version "4.4.1.3373"
+}
+
+apply plugin: 'com.android.application'
 
 allprojects {
     repositories {

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
@@ -186,6 +186,7 @@ public class ChartFragment extends Fragment implements TrackDataHub.Listener {
         }
     }
 
+    @Override
     public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics) {
         if (isResumed()) {
             ChartPoint point = ChartPoint.create(trackStatistics, trackPoint, trackPoint.getSpeed(), chartByDistance, viewBinding.chartView.getUnitSystem());


### PR DESCRIPTION
Added @Override to 'onSampledInTrackPoint' as it is defined in **Listener** interface

issue: GH-1


<img width="924" alt="TechDebt-Override" src="https://github.com/dneha1210/OpenTracks-Winter-SOEN-6431_2024-Group8/assets/145295037/107d8129-0b9d-4c47-852e-4f6eb8ceb5d8">
